### PR TITLE
Check for null before registering an eventsource.

### DIFF
--- a/src/NES/UnitOfWork.cs
+++ b/src/NES/UnitOfWork.cs
@@ -21,7 +21,8 @@ namespace NES
         {
             var eventSource = _eventSources.OfType<T>().SingleOrDefault(s => s.Id == id) ?? _eventSourceMapper.Get<T>(id);
 
-            Register(eventSource);
+            if (eventSource != null)
+                Register(eventSource);
 
             return eventSource;
         }


### PR DESCRIPTION
If you try to get an aggregate from a repository and it doesn't exist, it should not register the null as an eventsource.  If it does, and you have other events to commit when the unit of work ends, it blows up with a null reference exception in NES.EventSourceMapper.Set.
